### PR TITLE
Extract inline styles to external stylesheet

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,38 +1,44 @@
 /* Ensure fullscreen layout */
-body, html {
-	margin: 0;
-	padding: 0;
-	overflow: hidden; /* ✅ Prevents scrolling issues */
-	width: 100vw;
-	height: 100vh;
-	background-color: black; /* ✅ Prevents white flashes */
-  }
-  
-  /* Video container - ensures both videos are overlayed */
-  .video-container {
-	position: fixed; /* ✅ Keeps videos in place */
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
-	object-fit: cover; /* ✅ Maintains correct aspect ratio */
-	pointer-events: none;
-	z-index: 1; /* ✅ Both videos are aligned in the same z-layer */
-  }
-  
+body,
+html {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  width: 100vw;
+  height: 100vh;
+  background-color: black;
+}
 
-  
-  
-  /* Clickable Logo */
-  .logo {
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	width: min(80vw, 1000px);
-	max-width: 1000px;
-	height: auto;
-	cursor: pointer;
-	z-index: 3; /* ✅ Ensures logo is above both videos */
-  }
-  
+/* Common styles for both videos */
+.video-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  object-fit: cover;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* The top video has a circular reveal effect with feathered edges */
+.top-video {
+  position: absolute;
+  -webkit-mask-image: radial-gradient(circle, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 100%);
+  mask-image: radial-gradient(circle, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 100%);
+  transition: mask-image 0.05s ease-out, -webkit-mask-image 0.05s ease-out;
+}
+
+/* Clickable Logo */
+.logo {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80vw;
+  max-width: 1000px;
+  height: auto;
+  cursor: pointer;
+  z-index: 10;
+}
+

--- a/index.html
+++ b/index.html
@@ -4,48 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dreamachine</title>
-  <style>
-    /* Ensure fullscreen layout */
-    body, html {
-      margin: 0;
-      padding: 0;
-      overflow: hidden;
-      width: 100%;
-      height: 100%;
-    }
-
-    /* Common styles for both videos */
-    .video-container {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      pointer-events: none;
-    }
-
-    /* The top video has a circular reveal effect with feathered edges */
-    .top-video {
-      position: absolute;
-      -webkit-mask-image: radial-gradient(circle, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%);
-      mask-image: radial-gradient(circle, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%);
-      transition: mask-image 0.05s ease-out, -webkit-mask-image 0.05s ease-out;
-    }
-
-    /* Clickable Logo */
-    .logo {
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: 80vw;  /* Responsive: 80% of viewport width */
-      max-width: 1000px;  /* Prevents the logo from becoming too large */
-      height: auto;
-      cursor: pointer;
-      z-index: 10; /* Ensures it's above videos */
-    }
-  </style>
+  <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- move page styles from inline `<style>` block to `assets/style.css`
- add external stylesheet link in `<head>` and consolidate CSS declarations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689350165480833285c7ebb5f66098ca